### PR TITLE
support more than 25 sampling targets

### DIFF
--- a/xray/sampling/centralized_strategy.go
+++ b/xray/sampling/centralized_strategy.go
@@ -303,12 +303,12 @@ func (s *CentralizedStrategy) refreshQuota() {
 		}
 
 		for _, doc := range resp.SamplingTargetDocuments {
-			quota, ok := manifest.Quotas[aws.StringValue(doc.RuleName)]
-			if !ok {
+			if quota, ok := manifest.Quotas[aws.StringValue(doc.RuleName)]; ok {
+				quota.Update(doc)
+			} else {
 				// new rule may be added? try to refresh.
 				needRefresh = true
 			}
-			quota.Update(doc)
 		}
 		// check the rules are updated.
 		needRefresh = needRefresh || aws.TimeValue(resp.LastRuleModification).After(manifest.RefreshedAt)


### PR DESCRIPTION
https://docs.aws.amazon.com/xray/latest/api/API_GetSamplingTargets.html

> Request Body
> The request accepts the following data in JSON format.
> 
> SamplingStatisticsDocuments
> Information about rules that the service is using to sample requests.
> 
> Type: Array of SamplingStatisticsDocument objects
> 
> Array Members: Maximum number of 25 items.
> 
> Required: Yes