### PR TITLE
BREAKING: rename DynamicSegmentNamer to DynamicTracingNamer

### DIFF
--- a/xrayhttp/handler.go
+++ b/xrayhttp/handler.go
@@ -21,6 +21,7 @@ type TracingNamer interface {
 }
 
 // FixedTracingNamer records the fixed name of service node.
+// If it is empty string, the value of AWS_XRAY_TRACING_NAME environment value is used.
 type FixedTracingNamer string
 
 // TracingName implements TracingNamer.
@@ -37,6 +38,8 @@ func (tn FixedTracingNamer) TracingName(r *http.Request) string {
 // recognized pattern (using the included pattern package),
 // it is used as the segment name. Otherwise, the fallback
 // name is used.
+// If the fallback name is empty string,
+// the value of AWS_XRAY_TRACING_NAME environment value is used.
 type DynamicTracingNamer struct {
 	FallbackName    string
 	RecognizedHosts string

--- a/xrayhttp/handler.go
+++ b/xrayhttp/handler.go
@@ -31,19 +31,19 @@ func (tn FixedTracingNamer) TracingName(r *http.Request) string {
 	return os.Getenv("AWS_XRAY_TRACING_NAME")
 }
 
-// DynamicSegmentNamer chooses names for segments generated
+// DynamicTracingNamer chooses names for segments generated
 // for incoming requests by parsing the HOST header of the
 // incoming request. If the host header matches a given
 // recognized pattern (using the included pattern package),
 // it is used as the segment name. Otherwise, the fallback
 // name is used.
-type DynamicSegmentNamer struct {
+type DynamicTracingNamer struct {
 	FallbackName    string
 	RecognizedHosts string
 }
 
 // TracingName implements TracingNamer.
-func (tn *DynamicSegmentNamer) TracingName(r *http.Request) string {
+func (tn *DynamicTracingNamer) TracingName(r *http.Request) string {
 	if sampling.WildcardMatchCaseInsensitive(tn.RecognizedHosts, r.Host) {
 		return r.Host
 	}


### PR DESCRIPTION
The name of environment value for the segment is `AWS_XRAY_TRACING_NAME`.
So, `DynamicTracingNamer` should be `DynamicTracingNamer`.