### PR TITLE
rename fields of xray metadata

### DIFF
--- a/xray/metadata.go
+++ b/xray/metadata.go
@@ -9,8 +9,8 @@ import (
 // Version records the current X-Ray Go SDK version.
 const Version = "0.0.1"
 
-// Type records which X-Ray SDK customer uses.
-const Type = "X-Ray YA-SDK for Go"
+// Name records which X-Ray SDK customer uses.
+const Name = "X-Ray YA-SDK for Go"
 
 // ServiceData is the metadata of the user service.
 // It is used by all segments that X-Ray YA-SDK sends.

--- a/xray/plugin.go
+++ b/xray/plugin.go
@@ -50,9 +50,9 @@ func (xrayPlugin) HandleSegment(seg *Segment, doc *schema.Segment) {
 		doc.AWS = schema.AWS{}
 	}
 	doc.AWS.SetXRay(&schema.XRay{
-		SDKVersion: Version,
-		SDK:        Name,
-		RuleName:   seg.ruleName,
+		SDKVersion:       Version,
+		SDK:              Name,
+		SamplingRuleName: seg.ruleName,
 	})
 }
 

--- a/xray/plugin.go
+++ b/xray/plugin.go
@@ -50,9 +50,9 @@ func (xrayPlugin) HandleSegment(seg *Segment, doc *schema.Segment) {
 		doc.AWS = schema.AWS{}
 	}
 	doc.AWS.SetXRay(&schema.XRay{
-		Version:  Version,
-		Type:     Type,
-		RuleName: seg.ruleName,
+		SDKVersion: Version,
+		SDK:        Name,
+		RuleName:   seg.ruleName,
 	})
 }
 

--- a/xray/schema/schema.go
+++ b/xray/schema/schema.go
@@ -220,9 +220,9 @@ type EC2 struct {
 
 // XRay is information about X-Ray SDK.
 type XRay struct {
-	SDKVersion string `json:"sdk_version,omitempty"`
-	SDK        string `json:"sdk,omitempty"`
-	RuleName   string `json:"sampling_rule_name,omitempty"`
+	SDKVersion       string `json:"sdk_version,omitempty"`
+	SDK              string `json:"sdk,omitempty"`
+	SamplingRuleName string `json:"sampling_rule_name,omitempty"`
 }
 
 // ElasticBeanstalk is information about an Elastic Beanstalk environment.

--- a/xray/schema/schema.go
+++ b/xray/schema/schema.go
@@ -220,9 +220,9 @@ type EC2 struct {
 
 // XRay is information about X-Ray SDK.
 type XRay struct {
-	Version  string `json:"sdk_version,omitempty"`
-	Type     string `json:"sdk,omitempty"`
-	RuleName string `json:"sampling_rule_name,omitempty"`
+	SDKVersion string `json:"sdk_version,omitempty"`
+	SDK        string `json:"sdk,omitempty"`
+	RuleName   string `json:"sampling_rule_name,omitempty"`
 }
 
 // ElasticBeanstalk is information about an Elastic Beanstalk environment.

--- a/xray/segment_test.go
+++ b/xray/segment_test.go
@@ -16,7 +16,7 @@ import (
 var xrayData = schema.AWS{
 	"xray": map[string]interface{}{
 		"sdk_version": Version,
-		"sdk":         Type,
+		"sdk":         Name,
 	},
 }
 

--- a/xray/streaming_strategy_test.go
+++ b/xray/streaming_strategy_test.go
@@ -73,8 +73,8 @@ func TestStreamingStrategyBatchAll(t *testing.T) {
 			Service:   ServiceData,
 			AWS: schema.AWS{
 				"xray": &schema.XRay{
-					Version: Version,
-					Type:    Type,
+					SDKVersion: Version,
+					SDK:        Name,
 				},
 			},
 			Subsegments: []*schema.Segment{
@@ -185,8 +185,8 @@ func TestStreamingStrategyLimitSubsegment(t *testing.T) {
 				Service:    ServiceData,
 				AWS: schema.AWS{
 					"xray": &schema.XRay{
-						Version: Version,
-						Type:    Type,
+						SDKVersion: Version,
+						SDK:        Name,
 					},
 				},
 				Subsegments: []*schema.Segment{

--- a/xrayaws/client_test.go
+++ b/xrayaws/client_test.go
@@ -28,6 +28,12 @@ func ignoreVariableFieldFunc(in *schema.Segment) *schema.Segment {
 	out.StartTime = 0
 	out.EndTime = 0
 	out.Subsegments = nil
+	if out.AWS != nil {
+		delete(out.AWS, "xray")
+		if len(out.AWS) == 0 {
+			out.AWS = nil
+		}
+	}
 	if out.Cause != nil {
 		for i := range out.Cause.Exceptions {
 			out.Cause.Exceptions[i].ID = ""
@@ -132,12 +138,6 @@ func TestClient(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS: schema.AWS{
-			"xray": map[string]interface{}{
-				"sdk_version": xray.Version,
-				"sdk":         xray.Type,
-			},
-		},
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -247,12 +247,6 @@ func TestClient_FailDial(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS: schema.AWS{
-			"xray": map[string]interface{}{
-				"sdk_version": xray.Version,
-				"sdk":         xray.Type,
-			},
-		},
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -375,12 +369,6 @@ func TestClient_BadRequest(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS: schema.AWS{
-			"xray": map[string]interface{}{
-				"sdk_version": xray.Version,
-				"sdk":         xray.Type,
-			},
-		},
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/xrayhttp/client_test.go
+++ b/xrayhttp/client_test.go
@@ -26,6 +26,12 @@ func ignoreVariableFieldFunc(in *schema.Segment) *schema.Segment {
 	out.StartTime = 0
 	out.EndTime = 0
 	out.Subsegments = nil
+	if out.AWS != nil {
+		delete(out.AWS, "xray")
+		if len(out.AWS) == 0 {
+			out.AWS = nil
+		}
+	}
 	if out.Cause != nil {
 		for i := range out.Cause.Exceptions {
 			out.Cause.Exceptions[i].ID = ""
@@ -126,7 +132,6 @@ func TestClient(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -229,7 +234,6 @@ func TestClient_StatusTooManyRequests(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -331,7 +335,6 @@ func TestClient_StatusInternalServerError(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -450,7 +453,6 @@ func TestClient_TLS(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -568,7 +570,6 @@ func TestClient_DNS(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		dns["addresses"] = []interface{}{"::1", addr} // addresses may contains IPv6
@@ -673,7 +674,6 @@ func TestClient_InvalidDomain(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -777,7 +777,6 @@ func TestClient_InvalidAddress(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -892,7 +891,6 @@ func TestClient_InvalidCertificate(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -1009,7 +1007,6 @@ func TestClient_FailToReadResponse(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/xrayhttp/handler_test.go
+++ b/xrayhttp/handler_test.go
@@ -15,13 +15,6 @@ import (
 	"github.com/shogo82148/aws-xray-yasdk-go/xray/schema"
 )
 
-var xrayData = schema.AWS{
-	"xray": map[string]interface{}{
-		"sdk_version": xray.Version,
-		"sdk":         xray.Type,
-	},
-}
-
 // compile time checking to satisfy the interface
 // https://golang.org/doc/effective_go.html#blank_implements
 var _ http.ResponseWriter = (*serverResponseTracer)(nil)
@@ -110,7 +103,6 @@ func TestHandler(t *testing.T) {
 			{Name: "response"},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -170,7 +162,6 @@ func TestHandler_WriteString(t *testing.T) {
 			{Name: "response"},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -234,7 +225,6 @@ func TestHandler_ReadFrom(t *testing.T) {
 			{Name: "response"},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -308,7 +298,6 @@ func TestHandler_Hijack(t *testing.T) {
 			{Name: "response"},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -372,7 +361,6 @@ func TestHandler_Panic(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/xraysql/conn_test.go
+++ b/xraysql/conn_test.go
@@ -84,7 +84,6 @@ func TestConn_Exec(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -158,7 +157,6 @@ func TestConn_ExecContext(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -241,7 +239,6 @@ func TestConn_Query(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -324,7 +321,6 @@ func TestConn_QueryContext(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/xraysql/connector_test.go
+++ b/xraysql/connector_test.go
@@ -68,7 +68,6 @@ func TestConnect_postgresql(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -132,7 +131,6 @@ func TestConnect_mysql(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -200,7 +198,6 @@ func TestConnect_mssql(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -272,7 +269,6 @@ func TestConnect_oracle(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -332,7 +328,6 @@ func TestConnect_ConnContext(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/xraysql/stmt_test.go
+++ b/xraysql/stmt_test.go
@@ -84,7 +84,6 @@ func TestStmt_Exec(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -167,7 +166,6 @@ func TestStmt_Query(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/xraysql/tx_test.go
+++ b/xraysql/tx_test.go
@@ -124,7 +124,6 @@ func TestTx_Commit(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -244,7 +243,6 @@ func TestTx_Rollback(t *testing.T) {
 			},
 		},
 		Service: xray.ServiceData,
-		AWS:     xrayData,
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
because Go's field names are different from JSON representation.
