### PR TITLE
ignore patch update of aws-sdk-go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     interval: weekly
     time: "20:00"
   open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: github.com/aws/aws-sdk-go
+    versions:
+    - "> 1.33"
+    - "< 1.34"
 - package-ecosystem: gomod
   directory: "/xrayaws-v2"
   schedule:
@@ -18,12 +23,3 @@ updates:
     interval: weekly
     time: "20:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: github.com/aws/aws-sdk-go
-    versions:
-    - "> 1.30.12"
-    - "< 1.31"
-  - dependency-name: github.com/aws/aws-sdk-go
-    versions:
-    - "> 1.31.3"
-    - "< 1.32"

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
-github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/xrayaws/go.sum
+++ b/xrayaws/go.sum
@@ -1,5 +1,3 @@
-github.com/aws/aws-sdk-go v1.32.12 h1:l/djCeLI4ggBFWLlYUGTqkHraoLnVMubNlLXPdEtoYc=
-github.com/aws/aws-sdk-go v1.32.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.33.1 h1:yz9XmNzPshz/lhfAZvLfMnIS9HPo8+boGRcWqDVX+T0=
 github.com/aws/aws-sdk-go v1.33.1/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=


### PR DESCRIPTION
updating aws-sdk-go is too often.
ignore patch update of aws-sdk-go.