### PR TITLE
add runtime_version key

### DIFF
--- a/xray/metadata.go
+++ b/xray/metadata.go
@@ -12,6 +12,6 @@ const Name = "X-Ray YA-SDK for Go"
 // ServiceData is the metadata of the user service.
 // It is used by all segments that X-Ray YA-SDK sends.
 var ServiceData = &schema.Service{
-	Compiler:        runtime.Compiler,
-	CompilerVersion: runtime.Version(),
+	Runtime:        runtime.Compiler,
+	RuntimeVersion: runtime.Version(),
 }

--- a/xray/schema/schema.go
+++ b/xray/schema/schema.go
@@ -97,6 +97,9 @@ type Service struct {
 	// Version is a string that identifies the version of your application that served the request.
 	Version string `json:"version,omitempty"`
 
+	RuntimeVersion string `json:"runtime_version,omitempty"`
+	Runtime        string `json:"runtime,omitempty"`
+
 	Compiler        string `json:"compiler,omitempty"`
 	CompilerVersion string `json:"compiler_version,omitempty"`
 }

--- a/xray/schema/schema.go
+++ b/xray/schema/schema.go
@@ -100,8 +100,11 @@ type Service struct {
 	RuntimeVersion string `json:"runtime_version,omitempty"`
 	Runtime        string `json:"runtime,omitempty"`
 
-	Compiler        string `json:"compiler,omitempty"`
-	CompilerVersion string `json:"compiler_version,omitempty"`
+	// Compiler and CompilerVersion will be removed.
+	// They are defined only to keep backward compatibility.
+	// https://github.com/shogo82148/aws-xray-yasdk-go/pull/105
+	Compiler        string `json:"-"`
+	CompilerVersion string `json:"-"`
 }
 
 // HTTP is information about the original HTTP request.


### PR DESCRIPTION
port of "Added runtime and runtime_version key aws/aws-xray-sdk-go#245"

F.Y.I. the implementation of the other languages.

https://github.com/aws/aws-xray-sdk-java/blob/3d2c733a66cb3200a0bc5f2369d69ff5ef9bfc13/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java#L99-L107

https://github.com/aws/aws-xray-sdk-node/blob/39e08f340d55a135592b3f24e1207967e210e5cc/packages/core/lib/aws-xray.js#L346-L347