### PR TITLE
fix handling the error of QueryContext

### DIFF
--- a/xraysql/conn.go
+++ b/xraysql/conn.go
@@ -201,7 +201,7 @@ func (conn *driverConn) QueryContext(ctx context.Context, query string, args []d
 	}
 	conn.attr.populate(ctx, query)
 	seg.AddError(err)
-	return rows, nil
+	return rows, err
 }
 
 func (conn *driverConn) Close() error {


### PR DESCRIPTION
database/sql panics if the original QueryContext returns an error.
this pull request fixes it.

```
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 /usr/local/go/src/database/sql/sql.go:3168 +0x32
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 database/sql.withLock(0x12c2420, 0xc0002ce5a0, 0xc000226fa8)
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 /usr/local/go/src/database/sql/sql.go:3284 +0x69
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 database/sql.(*Rows).close(0xc000247980, 0x0, 0x0, 0x0, 0x0)
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 /usr/local/go/src/database/sql/sql.go:3167 +0x114
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 database/sql.(*Rows).Close(0xc000247980, 0x0, 0x0)
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 /usr/local/go/src/database/sql/sql.go:3151 +0x33
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 panic(0xfafb60, 0x193fbf0)
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 /usr/local/go/src/runtime/panic.go:969 +0x175
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 database/sql.(*Rows).nextLocked(0xc000247980, 0xfb0000)
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 /usr/local/go/src/database/sql/sql.go:2855 +0x21a
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 database/sql.(*Rows).Next.func1()
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 /usr/local/go/src/database/sql/sql.go:2836 +0x3c
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 database/sql.withLock(0x12c4ca0, 0xc0002479b0, 0xc0002272e0)
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 /usr/local/go/src/database/sql/sql.go:3284 +0x69
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 database/sql.(*Rows).Next(0xc000247980, 0x0)
2020-09-08T12:30:08.352000+00:00 i-0443186db885fef77 /usr/local/go/src/database/sql/sql.go:2835 +0x87
```