### PR TITLE
Import DetachContext from original SDK

### DIFF
--- a/xray/segment.go
+++ b/xray/segment.go
@@ -741,3 +741,10 @@ func (seg *Segment) AddAnnotationFloat64(key string, value float64) {
 func AddAnnotationFloat64(ctx context.Context, key string, value float64) {
 	ContextSegment(ctx).addAnnotation(key, value)
 }
+
+// DetachContextSegment returns a new context with the existing segment.
+// This is useful for creating background tasks which won't be cancelled
+// when a request completes.
+func DetachContextSegment(ctx context.Context) context.Context {
+	return context.WithValue(context.Background(), segmentContextKey, ContextSegment(ctx))
+}

--- a/xray/segment_test.go
+++ b/xray/segment_test.go
@@ -451,9 +451,9 @@ func TestDetachContextSegment(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	ctx1, _ := BeginSegment(ctx, "foobar")
 	ctx2 := DetachContextSegment(ctx1)
-	cancel()
+	cancel() // ctx1 is canceled.
 
-	seg := ContextSegment(ctx2)
+	seg := ContextSegment(ctx2) // get segment from ctx2
 	seg.Close()
 
 	want := &schema.Segment{

--- a/xray/segment_test.go
+++ b/xray/segment_test.go
@@ -441,6 +441,47 @@ func TestSegment_AddAnnotation(t *testing.T) {
 	}
 }
 
+func TestDetachContextSegment(t *testing.T) {
+	nowFunc = fixedTime
+	defer func() { nowFunc = time.Now }()
+
+	ctx, td := NewTestDaemon(nil)
+	defer td.Close()
+
+	ctx, cancel := context.WithCancel(ctx)
+	ctx1, _ := BeginSegment(ctx, "foobar")
+	ctx2 := DetachContextSegment(ctx1)
+	cancel()
+
+	seg := ContextSegment(ctx2)
+	seg.Close()
+
+	want := &schema.Segment{
+		Name:      "foobar",
+		ID:        seg.id,
+		TraceID:   seg.traceID,
+		StartTime: 1000000000,
+		EndTime:   1000000000,
+		Service:   ServiceData,
+		AWS:       xrayData,
+	}
+	got, err := td.Recv()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+
+	select {
+	case <-ctx2.Done():
+		t.Error(ctx2.Err())
+	default:
+		// ctx1 is canceled, but ctx2 is not.
+	}
+}
+
 func BenchmarkBeginSegment(b *testing.B) {
 	ctx, td := NewNullDaemon()
 	defer td.Close()


### PR DESCRIPTION
Imported `DetachContext` from original SDK renamed to `DetachContextSegment`. The original implemention can be found here: https://github.com/aws/aws-xray-sdk-go/blob/95821db08ed031914e88b3a7f06c95a943679375/xray/context.go#L70-L75