### PR TITLE
ignore patch releases of aws sdk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,7 @@ updates:
       interval: daily
     ignore:
       - dependency-name: github.com/aws/aws-sdk-go
-        versions:
-          - "< 1.39"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: gomod
     directory: "/xrayaws-v2"
     schedule:


### PR DESCRIPTION
https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore