### PR TITLE
Connector implements io.Closer

### DIFF
--- a/xraysql/connector.go
+++ b/xraysql/connector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
+	"io"
 	"reflect"
 	"strconv"
 	"sync"
@@ -357,4 +358,12 @@ func (attr *dbAttribute) populate(ctx context.Context, query string) {
 	}
 	seg.SetSQL(sqlData)
 	seg.SetNamespace("remote")
+}
+
+// from Go 1.17, the DB.Close method closes the connector field.
+func (c *driverConnector) Close() error {
+	if c, ok := c.Connector.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
 }


### PR DESCRIPTION
from Go 1.17, the DB.Close method closes the connector field.

> https://tip.golang.org/doc/go1.17#database/sql
> The DB.Close method now closes the connector field if the type in this field implements the io.Closer interface.

> https://tip.golang.org/pkg/database/sql/driver/#Connector
> If a Connector implements io.Closer, the sql package's DB.Close method will call Close and return error (if any).