### PR TITLE
fix short generator

### DIFF
--- a/xray/segment.go
+++ b/xray/segment.go
@@ -3,7 +3,9 @@ package xray
 import (
 	"context"
 	"crypto/rand"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"reflect"
@@ -139,8 +141,7 @@ type Segment struct {
 // NewTraceID generates a string format of random trace ID.
 func NewTraceID() string {
 	var r [12]byte
-	_, err := rand.Read(r[:])
-	if err != nil {
+	if _, err := io.ReadFull(rand.Reader, r[:]); err != nil {
 		panic(err)
 	}
 	return fmt.Sprintf("1-%08x-%x", nowFunc().Unix(), r)
@@ -162,11 +163,10 @@ func ContextTraceID(ctx context.Context) string {
 // NewSegmentID generates a string format of segment ID.
 func NewSegmentID() string {
 	var r [8]byte
-	_, err := rand.Read(r[:])
-	if err != nil {
+	if _, err := io.ReadFull(rand.Reader, r[:]); err != nil {
 		panic(err)
 	}
-	return fmt.Sprintf("%x", r)
+	return hex.EncodeToString(r[:])
 }
 
 // ContextSegment return the segment of current context.

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -140,11 +140,24 @@ type Segment struct {
 
 // NewTraceID generates a string format of random trace ID.
 func NewTraceID() string {
-	var r [12]byte
-	if _, err := io.ReadFull(rand.Reader, r[:]); err != nil {
+	var buf [35 + 12]byte // 35: dst, 12: i/o buf
+	buf[0] = '1'
+	buf[1] = '-'
+
+	r := buf[35:]
+	now := nowFunc().Unix()
+	r[0] = byte(now >> 24 & 0xff)
+	r[1] = byte(now >> 16 & 0xff)
+	r[2] = byte(now >> 8 & 0xff)
+	r[3] = byte(now & 0xff)
+	hex.Encode(buf[2:10], r[0:4])
+	buf[10] = '-'
+
+	if _, err := io.ReadFull(rand.Reader, r); err != nil {
 		panic(err)
 	}
-	return fmt.Sprintf("1-%08x-%x", nowFunc().Unix(), r)
+	hex.Encode(buf[11:35], r[:])
+	return string(buf[:35])
 }
 
 func withTraceID(ctx context.Context, traceID string) context.Context {
@@ -162,11 +175,12 @@ func ContextTraceID(ctx context.Context) string {
 
 // NewSegmentID generates a string format of segment ID.
 func NewSegmentID() string {
-	var r [8]byte
-	if _, err := io.ReadFull(rand.Reader, r[:]); err != nil {
+	var r [16 + 8]byte // 16: dst, 8: i/o buf
+	if _, err := io.ReadFull(rand.Reader, r[16:]); err != nil {
 		panic(err)
 	}
-	return hex.EncodeToString(r[:])
+	hex.Encode(r[:16], r[16:])
+	return string(r[:16])
 }
 
 // ContextSegment return the segment of current context.

--- a/xray/segment_test.go
+++ b/xray/segment_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -31,11 +32,23 @@ func TestNewTraceID(t *testing.T) {
 	}
 }
 
+func BenchmarkNewTraceID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		runtime.KeepAlive(NewTraceID())
+	}
+}
+
 func TestNewSegmentID(t *testing.T) {
 	id := NewSegmentID()
 	pattern := `^[0-9a-fA-F]{16}$`
 	if matched, err := regexp.MatchString(pattern, id); err != nil || !matched {
 		t.Errorf("id should match %q, but got %q", pattern, id)
+	}
+}
+
+func BenchmarkNewSegmentID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		runtime.KeepAlive(NewSegmentID())
 	}
 }
 

--- a/xray/test_daemon.go
+++ b/xray/test_daemon.go
@@ -181,6 +181,7 @@ func (td *NullDaemon) run() {
 		select {
 		case <-td.ctx.Done():
 			return
+		default:
 		}
 	}
 }


### PR DESCRIPTION
`rand.Read(buf)` is used in some places, but it doesn't guarantee to fill `buf`.
`io.ReadFull(rand.Reader, buf)` should be used instead of it.