### PR TITLE
introduce Grouped version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
 version: 2
 updates:
   - package-ecosystem: gomod
@@ -11,6 +14,11 @@ updates:
     directory: "/xrayaws-v2"
     schedule:
       interval: daily
+    groups:
+      aws-sdk:
+        patterns:
+          - github.com/aws/aws-sdk-go-v2
+          - github.com/aws/aws-sdk-go-v2/*
   - package-ecosystem: gomod
     directory: "/"
     schedule:


### PR DESCRIPTION
> Grouped version updates for Dependabot public beta

https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/