### PR TITLE
On Go 1.21 or later, DetachContextSegment is just an alias of context…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,19 @@ jobs:
           - windows-latest
           - macos-latest
         go:
-          - "1"
+          - "stable"
+          - "1.21.0-rc.4"
           - "1.20"
           - "1.19"
           - "1.18"
           - "1.17"
           - "1.16"
+        goexperiment: [""]
+        include:
+          # test with GOEXPERIMENT=loopvar
+          # https://github.com/golang/go/wiki/LoopvarExperiment
+          - go: "1.21.0-rc.4"
+            goexperiment: "loopvar"
 
     steps:
       - name: Check out code
@@ -32,16 +39,14 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - name: Install Dependencies
-        run: go mod download
-        shell: bash
-
       - name: Test
         run: |
           make test
           make test-xrayaws
           make test-xrayaws-v2
         shell: bash
+        env:
+          GOEXPERIMENT: ${{ matrix.goexperiment }}
 
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1

--- a/xray/detached_context_ge_go121.go
+++ b/xray/detached_context_ge_go121.go
@@ -1,0 +1,19 @@
+//go:build go1.21
+// +build go1.21
+
+package xray
+
+import (
+	"context"
+)
+
+// DetachContextSegment returns a new context with the existing segment.
+// All values associated with ctx are also associated with the new context.
+// This is useful for creating background tasks which won't be cancelled
+// when a request completes.
+//
+// On Go 1.21 or later, this function is just an alias of context.WithoutCancel.
+// Use context.WithoutCancel directly.
+func DetachContextSegment(ctx context.Context) context.Context {
+	return context.WithoutCancel(ctx)
+}

--- a/xray/detached_context_lt_go121.go
+++ b/xray/detached_context_lt_go121.go
@@ -1,0 +1,48 @@
+//go:build !go1.21
+// +build !go1.21
+
+package xray
+
+import (
+	"context"
+	"reflect"
+	"time"
+)
+
+// DetachContextSegment returns a new context with the existing segment.
+// All values associated with ctx are also associated with the new context.
+// This is useful for creating background tasks which won't be cancelled
+// when a request completes.
+func DetachContextSegment(ctx context.Context) context.Context {
+	return &detachedContext{Context: ctx}
+}
+
+type detachedContext struct {
+	context.Context
+}
+
+func (*detachedContext) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+func (*detachedContext) Done() <-chan struct{} {
+	return nil
+}
+
+func (*detachedContext) Err() error {
+	return nil
+}
+
+func (ctx *detachedContext) String() string {
+	return contextName(ctx.Context) + ".Detached"
+}
+
+func contextName(c context.Context) string {
+	type stringer interface {
+		String() string
+	}
+	if s, ok := c.(stringer); ok {
+		return s.String()
+	}
+	return reflect.TypeOf(c).String()
+}

--- a/xray/detached_context_test.go
+++ b/xray/detached_context_test.go
@@ -1,0 +1,51 @@
+package xray
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/shogo82148/aws-xray-yasdk-go/xray/schema"
+)
+
+func TestDetachContextSegment(t *testing.T) {
+	nowFunc = fixedTime
+	defer func() { nowFunc = time.Now }()
+
+	ctx, td := NewTestDaemon(nil)
+	defer td.Close()
+
+	ctx, cancel := context.WithCancel(ctx)
+	ctx1, _ := BeginSegment(ctx, "foobar")
+	ctx2 := DetachContextSegment(ctx1)
+	cancel() // ctx1 is canceled.
+
+	seg := ContextSegment(ctx2) // get segment from ctx2
+	seg.Close()
+
+	want := &schema.Segment{
+		Name:      "foobar",
+		ID:        seg.id,
+		TraceID:   seg.traceID,
+		StartTime: 1000000000,
+		EndTime:   1000000000,
+		Service:   ServiceData,
+		AWS:       xrayData,
+	}
+	got, err := td.Recv()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+
+	select {
+	case <-ctx2.Done():
+		t.Error(ctx2.Err())
+	default:
+		// ctx1 is canceled, but ctx2 is not.
+	}
+}

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -762,42 +761,4 @@ func (seg *Segment) AddAnnotationFloat64(key string, value float64) {
 // AddAnnotationFloat64 adds a 64 bit integer type annotation.
 func AddAnnotationFloat64(ctx context.Context, key string, value float64) {
 	ContextSegment(ctx).addAnnotation(key, value)
-}
-
-// DetachContextSegment returns a new context with the existing segment.
-// All values associated with ctx are also associated with the new context.
-// This is useful for creating background tasks which won't be cancelled
-// when a request completes.
-func DetachContextSegment(ctx context.Context) context.Context {
-	return &detachedContext{Context: ctx}
-}
-
-type detachedContext struct {
-	context.Context
-}
-
-func (*detachedContext) Deadline() (deadline time.Time, ok bool) {
-	return
-}
-
-func (*detachedContext) Done() <-chan struct{} {
-	return nil
-}
-
-func (*detachedContext) Err() error {
-	return nil
-}
-
-func (ctx *detachedContext) String() string {
-	return contextName(ctx.Context) + ".Detached"
-}
-
-func contextName(c context.Context) string {
-	type stringer interface {
-		String() string
-	}
-	if s, ok := c.(stringer); ok {
-		return s.String()
-	}
-	return reflect.TypeOf(c).String()
 }

--- a/xray/segment_test.go
+++ b/xray/segment_test.go
@@ -474,47 +474,6 @@ func TestSegment_AddAnnotation(t *testing.T) {
 	}
 }
 
-func TestDetachContextSegment(t *testing.T) {
-	nowFunc = fixedTime
-	defer func() { nowFunc = time.Now }()
-
-	ctx, td := NewTestDaemon(nil)
-	defer td.Close()
-
-	ctx, cancel := context.WithCancel(ctx)
-	ctx1, _ := BeginSegment(ctx, "foobar")
-	ctx2 := DetachContextSegment(ctx1)
-	cancel() // ctx1 is canceled.
-
-	seg := ContextSegment(ctx2) // get segment from ctx2
-	seg.Close()
-
-	want := &schema.Segment{
-		Name:      "foobar",
-		ID:        seg.id,
-		TraceID:   seg.traceID,
-		StartTime: 1000000000,
-		EndTime:   1000000000,
-		Service:   ServiceData,
-		AWS:       xrayData,
-	}
-	got, err := td.Recv()
-	if err != nil {
-		t.Error(err)
-	}
-
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
-
-	select {
-	case <-ctx2.Done():
-		t.Error(ctx2.Err())
-	default:
-		// ctx1 is canceled, but ctx2 is not.
-	}
-}
-
 func BenchmarkBeginSegment(b *testing.B) {
 	ctx, td := NewNullDaemon()
 	defer td.Close()


### PR DESCRIPTION
….WithoutCancel.