### PR TITLE
add support for net/http.ResponseController

### DIFF
--- a/xrayhttp/codegen.go
+++ b/xrayhttp/codegen.go
@@ -44,7 +44,10 @@ func generate(interfaces []string, path string) {
 
 	package xrayhttp
 
-	import "net/http"
+	import (
+		"io"
+		"net/http"
+	)
 	`)
 
 	g.Printf("func wrap(rw *serverResponseTracer) http.ResponseWriter {\n")
@@ -55,13 +58,13 @@ func generate(interfaces []string, path string) {
 
 	g.Printf("switch n {\n")
 	combinations := 1 << uint(len(interfaces))
-	values := make([]string, len(interfaces)+1)
+	values := make([]string, len(interfaces)+2)
 	for i := range values {
 		values[i] = "rw"
 	}
 	for i := 0; i < combinations; i++ {
 		fields := make([]string, 0, len(interfaces))
-		fields = append(fields, "responseWriter")
+		fields = append(fields, "http.ResponseWriter", "rwUnwrapper")
 		for j, iface := range interfaces {
 			ok := i&(1<<uint(j)) > 0
 			if ok {
@@ -90,5 +93,7 @@ func main() {
 		"http.CloseNotifier",
 		"http.Hijacker",
 		"http.Pusher",
+		"io.ReaderFrom",
+		"io.StringWriter",
 	}, "wrap.go")
 }

--- a/xrayhttp/handler_go1.20_test.go
+++ b/xrayhttp/handler_go1.20_test.go
@@ -1,3 +1,6 @@
+//go:build go1.20
+// +build go1.20
+
 package xrayhttp
 
 import (

--- a/xrayhttp/handler_go1.21_test.go
+++ b/xrayhttp/handler_go1.21_test.go
@@ -1,0 +1,29 @@
+package xrayhttp
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+type dummyReadDeadlineSetter struct {
+	http.ResponseWriter
+	called bool
+}
+
+func (rw *dummyReadDeadlineSetter) SetReadDeadline(deadline time.Time) error {
+	rw.called = true
+	return nil
+}
+
+func TestResponseController(t *testing.T) {
+	rw := &dummyReadDeadlineSetter{}
+	wrapped := wrap(&serverResponseTracer{rw: rw})
+	rc := http.NewResponseController(wrapped)
+	if err := rc.SetReadDeadline(time.Now()); err != nil {
+		t.Errorf("SetReadDeadline() = %v; want nil", err)
+	}
+	if !rw.called {
+		t.Error("SetReadDeadline() is not called")
+	}
+}

--- a/xrayhttp/handler_test.go
+++ b/xrayhttp/handler_test.go
@@ -462,7 +462,9 @@ func TestHandler_Flush(t *testing.T) {
 	h := Handler(FixedTracingNamer("test"), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
-		io.WriteString(w, "hello")
+		if _, err := io.WriteString(w, "hello"); err != nil {
+			panic(err)
+		}
 		w.(http.Flusher).Flush()
 	}))
 

--- a/xrayhttp/handler_test.go
+++ b/xrayhttp/handler_test.go
@@ -212,6 +212,16 @@ func TestHandler_context_canceled(t *testing.T) {
 	}
 }
 
+type dummyStringWriter struct {
+	http.ResponseWriter
+	called bool
+}
+
+func (rw *dummyStringWriter) WriteString(s string) (int, error) {
+	rw.called = true
+	return rw.ResponseWriter.Write([]byte(s))
+}
+
 func TestHandler_WriteString(t *testing.T) {
 	ctx, td := xray.NewTestDaemon(nil)
 	defer td.Close()
@@ -225,9 +235,12 @@ func TestHandler_WriteString(t *testing.T) {
 	}))
 
 	rec := httptest.NewRecorder()
+	rw := &dummyStringWriter{
+		ResponseWriter: rec,
+	}
 	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 	req = req.WithContext(ctx)
-	h.ServeHTTP(rec, req)
+	h.ServeHTTP(rw, req)
 
 	got, err := td.Recv()
 	if err != nil {
@@ -263,6 +276,9 @@ func TestHandler_WriteString(t *testing.T) {
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
+	if !rw.called {
+		t.Error("WriteString is not called")
+	}
 
 	res := rec.Result()
 	if res.StatusCode != http.StatusOK {
@@ -280,6 +296,16 @@ func TestHandler_WriteString(t *testing.T) {
 	}
 }
 
+type dummyReaderFrom struct {
+	http.ResponseWriter
+	called bool
+}
+
+func (rw *dummyReaderFrom) ReadFrom(r io.Reader) (n int64, err error) {
+	rw.called = true
+	return io.Copy(rw.ResponseWriter, r)
+}
+
 func TestHandler_ReadFrom(t *testing.T) {
 	ctx, td := xray.NewTestDaemon(nil)
 	defer td.Close()
@@ -292,14 +318,15 @@ func TestHandler_ReadFrom(t *testing.T) {
 		if _, err := dst.ReadFrom(src); err != nil {
 			panic(err)
 		}
-		f := w.(http.Flusher)
-		f.Flush()
 	}))
 
 	rec := httptest.NewRecorder()
+	rw := &dummyReaderFrom{
+		ResponseWriter: rec,
+	}
 	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 	req = req.WithContext(ctx)
-	h.ServeHTTP(rec, req)
+	h.ServeHTTP(rw, req)
 
 	got, err := td.Recv()
 	if err != nil {
@@ -416,6 +443,88 @@ func TestHandler_Hijack(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+type dummyFlusher struct {
+	http.ResponseWriter
+	called bool
+}
+
+func (rw *dummyFlusher) Flush() {
+	rw.called = true
+}
+
+func TestHandler_Flush(t *testing.T) {
+	ctx, td := xray.NewTestDaemon(nil)
+	defer td.Close()
+
+	h := Handler(FixedTracingNamer("test"), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "hello")
+		w.(http.Flusher).Flush()
+	}))
+
+	rec := httptest.NewRecorder()
+	rw := &dummyFlusher{
+		ResponseWriter: rec,
+	}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	req = req.WithContext(ctx)
+	h.ServeHTTP(rw, req)
+
+	got, err := td.Recv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &schema.Segment{
+		Name:      "test",
+		ID:        "xxxxxxxxxxxxxxxx",
+		TraceID:   "x-xxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx",
+		StartTime: timeFilled,
+		EndTime:   timeFilled,
+		HTTP: &schema.HTTP{
+			Request: &schema.HTTPRequest{
+				Method:   http.MethodGet,
+				URL:      "http://example.com",
+				ClientIP: "192.0.2.1",
+			},
+			Response: &schema.HTTPResponse{
+				Status:        http.StatusOK,
+				ContentLength: 5,
+			},
+		},
+		Subsegments: []*schema.Segment{
+			{
+				Name:      "response",
+				ID:        "xxxxxxxxxxxxxxxx",
+				StartTime: timeFilled,
+				EndTime:   timeFilled,
+			},
+		},
+		Service: xray.ServiceData,
+	}
+	if diff := cmp.Diff(want, got, ignoreVariableField); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+	if !rw.called {
+		t.Error("Flush is not called")
+	}
+
+	res := rec.Result()
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("want %d, got %d", http.StatusOK, res.StatusCode)
+	}
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("want %s, got %s", "hello", string(data))
+	}
+	if res.Header.Get("Content-Type") != "text/plain" {
+		t.Errorf("want %s, got %s", "text/plain", res.Header.Get("Content-Type"))
 	}
 }
 

--- a/xrayhttp/wrap.go
+++ b/xrayhttp/wrap.go
@@ -2,7 +2,10 @@
 
 package xrayhttp
 
-import "net/http"
+import (
+	"io"
+	"net/http"
+)
 
 func wrap(rw *serverResponseTracer) http.ResponseWriter {
 	var n uint
@@ -18,103 +21,525 @@ func wrap(rw *serverResponseTracer) http.ResponseWriter {
 	if _, ok := rw.rw.(http.Pusher); ok {
 		n |= 0x8
 	}
+	if _, ok := rw.rw.(io.ReaderFrom); ok {
+		n |= 0x10
+	}
+	if _, ok := rw.rw.(io.StringWriter); ok {
+		n |= 0x20
+	}
 	switch n {
 	case 0x0:
 		return struct {
-			responseWriter
-		}{rw}
+			http.ResponseWriter
+			rwUnwrapper
+		}{rw, rw}
 	case 0x1:
 		return struct {
-			responseWriter
+			http.ResponseWriter
+			rwUnwrapper
 			http.Flusher
-		}{rw, rw}
+		}{rw, rw, rw}
 	case 0x2:
 		return struct {
-			responseWriter
+			http.ResponseWriter
+			rwUnwrapper
 			http.CloseNotifier
-		}{rw, rw}
+		}{rw, rw, rw}
 	case 0x3:
 		return struct {
-			responseWriter
+			http.ResponseWriter
+			rwUnwrapper
 			http.Flusher
 			http.CloseNotifier
-		}{rw, rw, rw}
+		}{rw, rw, rw, rw}
 	case 0x4:
 		return struct {
-			responseWriter
+			http.ResponseWriter
+			rwUnwrapper
 			http.Hijacker
-		}{rw, rw}
+		}{rw, rw, rw}
 	case 0x5:
 		return struct {
-			responseWriter
+			http.ResponseWriter
+			rwUnwrapper
 			http.Flusher
 			http.Hijacker
-		}{rw, rw, rw}
+		}{rw, rw, rw, rw}
 	case 0x6:
 		return struct {
-			responseWriter
+			http.ResponseWriter
+			rwUnwrapper
 			http.CloseNotifier
 			http.Hijacker
-		}{rw, rw, rw}
+		}{rw, rw, rw, rw}
 	case 0x7:
 		return struct {
-			responseWriter
+			http.ResponseWriter
+			rwUnwrapper
 			http.Flusher
 			http.CloseNotifier
 			http.Hijacker
-		}{rw, rw, rw, rw}
+		}{rw, rw, rw, rw, rw}
 	case 0x8:
 		return struct {
-			responseWriter
+			http.ResponseWriter
+			rwUnwrapper
 			http.Pusher
-		}{rw, rw}
+		}{rw, rw, rw}
 	case 0x9:
 		return struct {
-			responseWriter
+			http.ResponseWriter
+			rwUnwrapper
 			http.Flusher
 			http.Pusher
-		}{rw, rw, rw}
+		}{rw, rw, rw, rw}
 	case 0xa:
 		return struct {
-			responseWriter
+			http.ResponseWriter
+			rwUnwrapper
 			http.CloseNotifier
 			http.Pusher
-		}{rw, rw, rw}
+		}{rw, rw, rw, rw}
 	case 0xb:
 		return struct {
-			responseWriter
+			http.ResponseWriter
+			rwUnwrapper
 			http.Flusher
 			http.CloseNotifier
 			http.Pusher
-		}{rw, rw, rw, rw}
+		}{rw, rw, rw, rw, rw}
 	case 0xc:
 		return struct {
-			responseWriter
+			http.ResponseWriter
+			rwUnwrapper
 			http.Hijacker
 			http.Pusher
-		}{rw, rw, rw}
+		}{rw, rw, rw, rw}
 	case 0xd:
 		return struct {
-			responseWriter
+			http.ResponseWriter
+			rwUnwrapper
 			http.Flusher
 			http.Hijacker
 			http.Pusher
-		}{rw, rw, rw, rw}
+		}{rw, rw, rw, rw, rw}
 	case 0xe:
 		return struct {
-			responseWriter
-			http.CloseNotifier
-			http.Hijacker
-			http.Pusher
-		}{rw, rw, rw, rw}
-	case 0xf:
-		return struct {
-			responseWriter
-			http.Flusher
+			http.ResponseWriter
+			rwUnwrapper
 			http.CloseNotifier
 			http.Hijacker
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
+	case 0xf:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x10:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			io.ReaderFrom
+		}{rw, rw, rw}
+	case 0x11:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			io.ReaderFrom
+		}{rw, rw, rw, rw}
+	case 0x12:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.CloseNotifier
+			io.ReaderFrom
+		}{rw, rw, rw, rw}
+	case 0x13:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+		}{rw, rw, rw, rw, rw}
+	case 0x14:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Hijacker
+			io.ReaderFrom
+		}{rw, rw, rw, rw}
+	case 0x15:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+		}{rw, rw, rw, rw, rw}
+	case 0x16:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+		}{rw, rw, rw, rw, rw}
+	case 0x17:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x18:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Pusher
+			io.ReaderFrom
+		}{rw, rw, rw, rw}
+	case 0x19:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.Pusher
+			io.ReaderFrom
+		}{rw, rw, rw, rw, rw}
+	case 0x1a:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.CloseNotifier
+			http.Pusher
+			io.ReaderFrom
+		}{rw, rw, rw, rw, rw}
+	case 0x1b:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.CloseNotifier
+			http.Pusher
+			io.ReaderFrom
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x1c:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Hijacker
+			http.Pusher
+			io.ReaderFrom
+		}{rw, rw, rw, rw, rw}
+	case 0x1d:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.Hijacker
+			http.Pusher
+			io.ReaderFrom
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x1e:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.CloseNotifier
+			http.Hijacker
+			http.Pusher
+			io.ReaderFrom
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x1f:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			http.Pusher
+			io.ReaderFrom
+		}{rw, rw, rw, rw, rw, rw, rw}
+	case 0x20:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			io.StringWriter
+		}{rw, rw, rw}
+	case 0x21:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			io.StringWriter
+		}{rw, rw, rw, rw}
+	case 0x22:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.CloseNotifier
+			io.StringWriter
+		}{rw, rw, rw, rw}
+	case 0x23:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.CloseNotifier
+			io.StringWriter
+		}{rw, rw, rw, rw, rw}
+	case 0x24:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Hijacker
+			io.StringWriter
+		}{rw, rw, rw, rw}
+	case 0x25:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.Hijacker
+			io.StringWriter
+		}{rw, rw, rw, rw, rw}
+	case 0x26:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.CloseNotifier
+			http.Hijacker
+			io.StringWriter
+		}{rw, rw, rw, rw, rw}
+	case 0x27:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x28:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Pusher
+			io.StringWriter
+		}{rw, rw, rw, rw}
+	case 0x29:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.Pusher
+			io.StringWriter
+		}{rw, rw, rw, rw, rw}
+	case 0x2a:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.CloseNotifier
+			http.Pusher
+			io.StringWriter
+		}{rw, rw, rw, rw, rw}
+	case 0x2b:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.CloseNotifier
+			http.Pusher
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x2c:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Hijacker
+			http.Pusher
+			io.StringWriter
+		}{rw, rw, rw, rw, rw}
+	case 0x2d:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.Hijacker
+			http.Pusher
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x2e:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.CloseNotifier
+			http.Hijacker
+			http.Pusher
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x2f:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			http.Pusher
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw, rw}
+	case 0x30:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw}
+	case 0x31:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw}
+	case 0x32:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.CloseNotifier
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw}
+	case 0x33:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x34:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Hijacker
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw}
+	case 0x35:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x36:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x37:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw, rw}
+	case 0x38:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Pusher
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw}
+	case 0x39:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.Pusher
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x3a:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.CloseNotifier
+			http.Pusher
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x3b:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.CloseNotifier
+			http.Pusher
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw, rw}
+	case 0x3c:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Hijacker
+			http.Pusher
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw}
+	case 0x3d:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.Hijacker
+			http.Pusher
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw, rw}
+	case 0x3e:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.CloseNotifier
+			http.Hijacker
+			http.Pusher
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw, rw}
+	case 0x3f:
+		return struct {
+			http.ResponseWriter
+			rwUnwrapper
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			http.Pusher
+			io.ReaderFrom
+			io.StringWriter
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
 	}
 	panic("unreachable")
 }

--- a/xrayhttp/wrap_test.go
+++ b/xrayhttp/wrap_test.go
@@ -7,30 +7,6 @@ import (
 	"testing"
 )
 
-type dummyFlusher struct {
-	http.ResponseWriter
-}
-
-func (dummyFlusher) Flush() {
-	panic("unreachable")
-}
-
-func TestWrap_Flusher(t *testing.T) {
-	got := wrap(&serverResponseTracer{rw: dummyFlusher{}})
-	if _, ok := got.(http.Flusher); !ok {
-		t.Error("want to implement http.Flusher, but it doesn't")
-	}
-	if _, ok := got.(http.CloseNotifier); ok {
-		t.Error("want not to implement http.CloseNotifier, but it does")
-	}
-	if _, ok := got.(http.Hijacker); ok {
-		t.Error("want not to implement http.Hijacker, but it does")
-	}
-	if _, ok := got.(http.Pusher); ok {
-		t.Error("want not to implement http.Pusher, but it does")
-	}
-}
-
 type dummyCloseNotifier struct {
 	http.ResponseWriter
 }


### PR DESCRIPTION
`net/http.ResponseController` is available from Go 1.20.

- https://go.dev/doc/go1.20#http_responsecontroller
- https://future-architect.github.io/articles/20230128a/
- https://www.alexedwards.net/blog/how-to-use-the-http-responsecontroller-type