### PR TITLE
remove "skip fast-path" on SQL.

### DIFF
--- a/xrayaws/go.mod
+++ b/xrayaws/go.mod
@@ -3,7 +3,7 @@ module github.com/shogo82148/aws-xray-yasdk-go/xrayaws
 go 1.18
 
 require (
-	github.com/aws/aws-sdk-go v1.45.0
+	github.com/aws/aws-sdk-go v1.45.2
 	github.com/google/go-cmp v0.5.9
 	github.com/shogo82148/aws-xray-yasdk-go v1.6.0
 )

--- a/xrayaws/go.sum
+++ b/xrayaws/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go v1.45.0 h1:qoVOQHuLacxJMO71T49KeE70zm+Tk3vtrl7XO4VUPZc=
-github.com/aws/aws-sdk-go v1.45.0/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.45.2 h1:hTong9YUklQKqzrGk3WnKABReb5R8GjbG4Y6dEQfjnk=
+github.com/aws/aws-sdk-go v1.45.2/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=

--- a/xraysql/connector.go
+++ b/xraysql/connector.go
@@ -361,8 +361,13 @@ func queryRow(ctx context.Context, conn driver.Conn, query string, dest ...*stri
 	return nil
 }
 
+// populate adds SQL data to the current segment.
 func (attr *dbAttribute) populate(ctx context.Context, query string) {
 	seg := xray.ContextSegment(ctx)
+	attr.populateToSegment(seg, query)
+}
+
+func (attr *dbAttribute) populateToSegment(seg *xray.Segment, query string) {
 	sqlData := &schema.SQL{
 		ConnectionString: attr.connectionString,
 		URL:              attr.url,

--- a/xraysql/fakedb_test.go
+++ b/xraysql/fakedb_test.go
@@ -79,7 +79,7 @@ func (d *fakeDriver) Open(name string) (driver.Conn, error) {
 	return connector.Connect(context.Background())
 }
 
-// fakeConn is minimum implementation of driver.Conn
+// fakeConn is minimum implementation of [database/sql/driver.Conn].
 type fakeConn struct {
 	db  *fakeDB
 	opt *FakeConnOption
@@ -91,7 +91,7 @@ type fakeTx struct {
 	opt *FakeConnOption
 }
 
-// fakeStmt is minimum implementation of driver.Stmt
+// fakeStmt is minimum implementation of [database/sql/driver.Stmt].
 type fakeStmt struct {
 	db    *fakeDB
 	query string

--- a/xraysql/sql.go
+++ b/xraysql/sql.go
@@ -39,10 +39,6 @@ func WithName(name string) Option {
 	}
 }
 
-// we can't know that the original driver will return driver.ErrSkip in advance.
-// so we add this message to the query if it returns driver.ErrSkip.
-const msgErrSkip = " -- skip fast-path; continue as if unimplemented"
-
 // Open xxx
 func Open(driverName, dataSourceName string, opts ...Option) (*sql.DB, error) {
 	name, err := registerDriver(driverName, dataSourceName, opts...)


### PR DESCRIPTION
Currently we log " -- skip fast-path; continue as if unimplemented" if the original SQL driver returns driver.ErrSkip. but it is very noisy.