### PR TITLE
drop support of Go 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Test
 on: [push, pull_request]
 
-env:
-  GO111MODULE: "on"
-
 jobs:
   test:
     name: Go ${{ matrix.go }} Test on ${{ matrix.os }}
@@ -17,17 +14,10 @@ jobs:
           - macos-latest
         go:
           - "stable"
+          - "1.22"
           - "1.21"
           - "1.20"
           - "1.19"
-          - "1.18"
-        goexperiment: [""]
-        include:
-          # test with GOEXPERIMENT=loopvar
-          # https://github.com/golang/go/wiki/LoopvarExperiment
-          - go: "1.21"
-            os: ubuntu-latest
-            goexperiment: "loopvar"
 
     steps:
       - name: Check out code
@@ -44,8 +34,6 @@ jobs:
           make test-xrayaws
           make test-xrayaws-v2
         shell: bash
-        env:
-          GOEXPERIMENT: ${{ matrix.goexperiment }}
 
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/aws-xray-yasdk-go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/xrayaws-v2/go.mod
+++ b/xrayaws-v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/aws-xray-yasdk-go/xrayaws-v2
 
-go 1.18
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.27.2


### PR DESCRIPTION
AWS SDK for Go v2 no longer supports Go 1.18. ref. https://github.com/shogo82148/aws-xray-yasdk-go/pull/570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Go version to 1.19 in module dependencies.
  - Updated Go versions used in CI workflows.
  - Removed deprecated environment variables and configurations in CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->