### PR TITLE
bump shogo82148/go-retry v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.19
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/shogo82148/forwarded-header v0.1.0
-	github.com/shogo82148/go-retry v1.3.1
+	github.com/shogo82148/go-retry/v2 v2.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,5 @@ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/shogo82148/forwarded-header v0.1.0 h1:OZX131i0B8GGZR+s5QEZdSEYDTUPkUX8ISIIQE+swKM=
 github.com/shogo82148/forwarded-header v0.1.0/go.mod h1:Ge73zEgn9jrdyf65vWTgDmRZQFQPHoFU0TaILJcvs54=
-github.com/shogo82148/go-retry v1.3.1 h1:AFJHUWG7mLzLFN/21p3NdzdL55ttZgdapWaFgbtYf8g=
-github.com/shogo82148/go-retry v1.3.1/go.mod h1:wttfgfwCMQvNqv4kOpqIvDDJeSmwU+AEIpUyG+5Ca6M=
+github.com/shogo82148/go-retry/v2 v2.0.1 h1:GV20np5IPU+pjFuNzFwmkFK90Lw3g4HhKgMVHewclb8=
+github.com/shogo82148/go-retry/v2 v2.0.1/go.mod h1:Rv6PnVPeGd1695eqstyZ+VFOQN8vsh5t87/Ur+aa9JI=

--- a/plugins/ec2/ec2.go
+++ b/plugins/ec2/ec2.go
@@ -33,7 +33,7 @@ import (
 	"github.com/shogo82148/aws-xray-yasdk-go/xray"
 	"github.com/shogo82148/aws-xray-yasdk-go/xray/schema"
 	"github.com/shogo82148/aws-xray-yasdk-go/xray/xraylog"
-	"github.com/shogo82148/go-retry"
+	"github.com/shogo82148/go-retry/v2"
 )
 
 type ec2InstanceIdentityDocument struct {

--- a/plugins/ec2/ec2_test.go
+++ b/plugins/ec2/ec2_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/shogo82148/aws-xray-yasdk-go/xray/schema"
-	"github.com/shogo82148/go-retry"
+	"github.com/shogo82148/go-retry/v2"
 )
 
 func TestGetInstanceIdentityDocument_IMDSv1(t *testing.T) {

--- a/plugins/ecs/ecs.go
+++ b/plugins/ecs/ecs.go
@@ -27,7 +27,7 @@ import (
 	"github.com/shogo82148/aws-xray-yasdk-go/internal/envconfig"
 	"github.com/shogo82148/aws-xray-yasdk-go/xray"
 	"github.com/shogo82148/aws-xray-yasdk-go/xray/schema"
-	"github.com/shogo82148/go-retry"
+	"github.com/shogo82148/go-retry/v2"
 )
 
 const cgroupPath = "/proc/self/cgroup"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency `github.com/shogo82148/go-retry` to version `v2.0.1` for improved reliability and performance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->