### PR TITLE
add Go 1.23 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
           - macos-latest
         go:
           - "stable"
+          - "1.23"
           - "1.22"
           - "1.21"
           - "1.20"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Go version 1.23 in the testing workflow, ensuring compatibility with the latest features.
- **Chores**
	- Updated the list of Go versions in the GitHub Actions configuration to include version 1.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->